### PR TITLE
log: change unknown packet to use raw data, not parsed

### DIFF
--- a/aoe2dashboard/client.py
+++ b/aoe2dashboard/client.py
@@ -207,11 +207,11 @@ class Client(object):
         pass
 
     async def event_unanalyzed(self, packet: PacketBase) -> None:
-        self.__logger.debug(f"unanalyzed packet: {packet.raw_data}")
+        self.__logger.debug(f"unanalyzed packet: '{packet.raw}'")
         # self.__logger.debug(f"unknown packet: {dumps(packet.raw, indent=2)}")
 
     async def event_unknown(self, packet: PacketBase) -> None:
-        self.__logger.warning(f"unknown packet: {packet.raw}")
+        self.__logger.warning(f"unknown packet: '{packet.raw}'")
         # self.__logger.debug(f"unknown packet: {dumps(packet.raw, indent=2)}")
 
     async def event_login(self, packet: PacketBase) -> None:


### PR DESCRIPTION
Some of the packets appear to be missing the 'data' field and therefore are logged as 'None' which is unhelpful to the end-user. Change it to the raw string which has a chance of actually being analyzed and processed appropriately.